### PR TITLE
Prefix the legacy lifecycle methods with UNSAFE_* to avoid warning in…

### DIFF
--- a/benchmarks/src/app/Benchmark/index.js
+++ b/benchmarks/src/app/Benchmark/index.js
@@ -118,13 +118,13 @@ export default class Benchmark extends Component<BenchmarkPropsType, BenchmarkSt
     this._samples = [];
   }
 
-  componentWillReceiveProps(nextProps: BenchmarkPropsType) {
+  UNSAFE_componentWillReceiveProps(nextProps: BenchmarkPropsType) {
     if (nextProps) {
       this.setState(state => ({ componentProps: nextProps.getComponentProps(state.cycle) }));
     }
   }
 
-  componentWillUpdate(nextProps: BenchmarkPropsType, nextState: BenchmarkStateType) {
+  UNSAFE_componentWillUpdate(nextProps: BenchmarkPropsType, nextState: BenchmarkStateType) {
     if (nextState.running && !this.state.running) {
       this._startTime = Timing.now();
     }

--- a/example/with-perf.html
+++ b/example/with-perf.html
@@ -41,7 +41,7 @@
 
 
       class ExampleWithPerf extends React.Component {
-        componentWillMount() {
+        UNSAFE_componentWillMount() {
           Perf.start();
         }
 
@@ -62,7 +62,7 @@
 					}, 1000)
         }
 
-        componentWillReceiveProps() {
+        UNSAFE_componentWillReceiveProps() {
           Perf.start()
         }
 

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "puppeteer": "^1.5.0",
     "raf": "^3.4.0",
     "react": "^16.3.0",
-    "react-dom": "^16.0.0",
+    "react-dom": "~16.3.0",
     "react-frame-component": "^2.0.2",
     "react-native": "^0.46.0",
     "react-primitives": "^0.4.2",

--- a/src/hoc/withTheme.js
+++ b/src/hoc/withTheme.js
@@ -28,7 +28,8 @@ export default (Component: ComponentType<any>) => {
     state: { theme?: ?Object } = EMPTY_OBJECT
     unsubscribeId: number = -1
 
-    componentWillMount() {
+    // eslint-disable-next-line camelcase
+    UNSAFE_componentWillMount() {
       const { defaultProps } = this.constructor
       const styledContext = this.context[CHANNEL_NEXT]
       const themeProp = determineTheme(this.props, undefined, defaultProps)
@@ -52,7 +53,8 @@ export default (Component: ComponentType<any>) => {
       }
     }
 
-    componentWillReceiveProps(nextProps: {
+    // eslint-disable-next-line camelcase
+    UNSAFE_componentWillReceiveProps(nextProps: {
       theme?: ?Object,
       [key: string]: any,
     }) {

--- a/src/models/StyleSheetManager.js
+++ b/src/models/StyleSheetManager.js
@@ -35,7 +35,8 @@ export default class StyleSheetManager extends Component<Props, void> {
     return { [CONTEXT_KEY]: this.sheetInstance }
   }
 
-  componentWillMount() {
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillMount() {
     if (this.props.sheet) {
       this.sheetInstance = this.props.sheet
     } else if (this.props.target) {

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -148,7 +148,8 @@ class BaseStyledComponent extends Component<*, BaseState> {
     }
   }
 
-  componentWillMount() {
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillMount() {
     const { componentStyle } = this.constructor
     const styledContext = this.context[CHANNEL_NEXT]
 
@@ -188,7 +189,11 @@ class BaseStyledComponent extends Component<*, BaseState> {
     }
   }
 
-  componentWillReceiveProps(nextProps: { theme?: Theme, [key: string]: any }) {
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillReceiveProps(nextProps: {
+    theme?: Theme,
+    [key: string]: any,
+  }) {
     // If this is a statically-styled component, we don't need to listen to
     // props changes to update styles
     const { componentStyle } = this.constructor

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -78,7 +78,8 @@ class BaseStyledNativeComponent extends Component<*, State> {
     return inlineStyle.generateStyleObject(executionContext)
   }
 
-  componentWillMount() {
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillMount() {
     // If there is a theme in the context, subscribe to the event emitter. This
     // is necessary due to pure components blocking context updates, this circumvents
     // that by updating when an event is emitted
@@ -104,7 +105,11 @@ class BaseStyledNativeComponent extends Component<*, State> {
     }
   }
 
-  componentWillReceiveProps(nextProps: { theme?: Theme, [key: string]: any }) {
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillReceiveProps(nextProps: {
+    theme?: Theme,
+    [key: string]: any,
+  }) {
     this.setState(prevState => {
       const theme = determineTheme(
         nextProps,

--- a/src/models/ThemeProvider.js
+++ b/src/models/ThemeProvider.js
@@ -61,7 +61,8 @@ export default class ThemeProvider extends Component<ThemeProviderProps, void> {
     this.getTheme = this.getTheme.bind(this)
   }
 
-  componentWillMount() {
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillMount() {
     // If there is a ThemeProvider wrapper anywhere around this theme provider, merge this theme
     // with the outer theme
     const outerContext = this.context[CHANNEL_NEXT]
@@ -98,7 +99,8 @@ export default class ThemeProvider extends Component<ThemeProviderProps, void> {
     }
   }
 
-  componentWillReceiveProps(nextProps: ThemeProviderProps) {
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillReceiveProps(nextProps: ThemeProviderProps) {
     if (this.props.theme !== nextProps.theme) {
       this.publish(nextProps.theme)
     }

--- a/src/models/test/ThemeProvider.test.js
+++ b/src/models/test/ThemeProvider.test.js
@@ -29,7 +29,7 @@ describe('ThemeProvider', () => {
     const innerTheme = { secondary: 'black' }
     // Setup Child
     class Child extends React.Component {
-      componentWillMount() {
+      UNSAFE_componentWillMount() {
         this.context[CHANNEL_NEXT].subscribe(theme => {
           expect(theme).toEqual({ ...outerTheme, ...innerTheme })
           done()
@@ -56,7 +56,7 @@ describe('ThemeProvider', () => {
     const innerTheme = { secondary: 'black' }
     // Setup Child
     class Child extends React.Component {
-      componentWillMount() {
+      UNSAFE_componentWillMount() {
         this.context[CHANNEL_NEXT].subscribe(theme => {
           expect(theme).toEqual({ ...outerestTheme, ...outerTheme, ...innerTheme })
           done()
@@ -87,7 +87,7 @@ describe('ThemeProvider', () => {
     let childRendered = 0
     // Setup Child
     class Child extends React.Component {
-      componentWillMount() {
+      UNSAFE_componentWillMount() {
         this.context[CHANNEL_NEXT].subscribe(theme => {
           // eslint-disable-next-line react/prop-types
           expect(theme).toEqual(themes[this.props.shouldHaveTheme])
@@ -125,7 +125,7 @@ describe('ThemeProvider', () => {
 
     // Setup Child
     class Child extends React.Component {
-      componentWillMount() {
+      UNSAFE_componentWillMount() {
         this.context[CHANNEL_NEXT].subscribe(receivedTheme => {
           actual = receivedTheme
         })

--- a/yarn.lock
+++ b/yarn.lock
@@ -6877,9 +6877,10 @@ react-devtools-core@2.3.1:
     shell-quote "^1.6.1"
     ws "^2.0.3"
 
-react-dom@^16.0.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
+react-dom@~16.3.0:
+  version "16.3.3"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.3.3.tgz#af4c2aef9f6a66251a46da50253c860a67ae66d9"
+  integrity sha512-ALCp7ZbSGkqRDtQoZozKVNgwXMxbxf/IGOUMC2A0yF6JHeZrS8e2cOotPT87Vf4b7PKCuUVKU4/RDEXxToA/yA==
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"


### PR DESCRIPTION
… React 16.9+

More information about the deprecation of lifecycles methods can be found here:
https://reactjs.org/blog/2018/03/29/react-v-16-3.html#component-lifecycle-changes